### PR TITLE
Rewrite axis and remapper modules

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ select = B,C,E,F,W,T4,B9
 
 [isort]
 known_first_party=intake_esm
-known_third_party=numpy,pandas,pkg_resources,pytest,scipy,setuptools,sparse,xarray
+known_third_party=numpy,pandas,pkg_resources,pytest,setuptools,sparse,xarray
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ select = B,C,E,F,W,T4,B9
 
 [isort]
 known_first_party=intake_esm
-known_third_party=numpy,pandas,pkg_resources,pytest,setuptools,sparse,xarray
+known_third_party=numpy,pandas,pkg_resources,pytest,scipy,setuptools,sparse,xarray
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/tests/test_axis.py
+++ b/tests/test_axis.py
@@ -3,8 +3,7 @@ import itertools
 import numpy as np
 import pytest
 
-from xtimeutil import Axis
-from xtimeutil.axis import _infer_time_data_tick_binding
+from xtimeutil.axis import _infer_time_data_tick_binding, get_time_axis_info
 from xtimeutil.testing import create_dataset
 
 # cftime config
@@ -29,17 +28,17 @@ def test_init_axis(time_units, calendar, decode_times, use_cftime):
     ds = create_dataset(
         units=time_units, calendar=calendar, use_cftime=use_cftime, decode_times=decode_times,
     )
-    axis = Axis(ds)
-    assert axis.attrs['is_time_decoded'] == decode_times
-    assert axis.decoded_times.shape == ds.time.shape
+    info = get_time_axis_info(ds)
+    assert info['is_time_decoded'] == decode_times
+    assert info['decoded_times'].shape == ds.time.shape
 
 
 def test_init_axis_with_attrs_from_encoding():
     ds = create_dataset()
     ds.time.encoding = ds.time.attrs
     ds.time.attrs = {}
-    axis = Axis(ds)
-    assert isinstance(axis.attrs, dict)
+    info = get_time_axis_info(ds)
+    assert isinstance(info, dict)
 
 
 def test_init_missing_bounds():
@@ -47,19 +46,19 @@ def test_init_missing_bounds():
     ds = ds.drop_vars(['time_bounds'])
     del ds.time.attrs['bounds']
     with pytest.raises(RuntimeError):
-        _ = Axis(ds)
+        _ = get_time_axis_info(ds)
 
 
 def test_validate_time_coord():
     ds = create_dataset(var_const=False)
     with pytest.raises(KeyError):
-        _ = Axis(ds, 'times')
+        _ = get_time_axis_info(ds, 'times')
 
 
 def test_invalid_binding():
     ds = create_dataset(var_const=True)
     with pytest.raises(KeyError):
-        _ = Axis(ds, 'time', 'center')
+        _ = get_time_axis_info(ds, 'time', 'center')
 
 
 def test_infer_time_data_tick_binding():

--- a/tests/test_remapper.py
+++ b/tests/test_remapper.py
@@ -64,23 +64,9 @@ def test_init_remapper(time_units, calendar, decode_times, use_cftime, freq, bin
     )
 
     remapper = Remapper(ds, freq=freq, binding=binding)
-    assert isinstance(remapper.info, xr.Dataset)
-    assert {'outgoing_time_bounds', 'weights'}.issubset(set(remapper.info.variables))
-    assert isinstance(remapper.info.weights.data, sparse._coo.core.COO)
-    assert set(
-        [
-            'freq',
-            'binding',
-            'is_time_decoded',
-            'time_coord_name',
-            'units',
-            'calendar',
-            'time_bounds_varname',
-            'time_bounds_dim',
-            'time_bounds_dim_axis_num',
-            'use_cftime',
-        ]
-    ) == set(remapper.info.attrs.keys())
+    assert isinstance(remapper.info, dict)
+    assert remapper.outgoing['encoded_times'].attrs == ds.time.attrs
+    assert isinstance(remapper.weights, sparse._coo.core.COO)
 
 
 @pytest.mark.parametrize('use_cftime', [True, False])
@@ -95,6 +81,7 @@ def test_invalid_out_freq():
         _validate_freq(freq='QM')
 
 
+@pytest.mark.xfail(reason='Will be supported at a later time')
 @pytest.mark.parametrize(
     'start, end, in_freq, out_freq, nlats, nlons, group',
     [
@@ -114,6 +101,7 @@ def test_remapper_average(start, end, in_freq, out_freq, nlats, nlons, group):
     np.testing.assert_almost_equal(expected, results, verbose=True)
 
 
+@pytest.mark.xfail(reason='Will be supported at a later time')
 @pytest.mark.parametrize(
     'start, end, in_freq, out_freq, nlats, nlons, group',
     [
@@ -136,6 +124,7 @@ def test_remapper_average_w_transposed_dims(start, end, in_freq, out_freq, nlats
     np.testing.assert_almost_equal(expected, results)
 
 
+@pytest.mark.xfail(reason='Will be supported at a later time')
 def test_remapper_input_time_axis_mismatch():
     ds = create_dataset(start='2018-01-01', end='2018-01-07', freq='D')
     remapper = Remapper(ds, freq='7D')

--- a/xtimeutil/__init__.py
+++ b/xtimeutil/__init__.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
-""" Top-level module for xtime. """
+""" Top-level module for xtimeutil. """
 from pkg_resources import DistributionNotFound, get_distribution
 
-# from .axis import Axis  # noqa: F401
-# from .remapper import Remapper  # noqa: F401
+from .remapper import Remapper  # noqa: F401
 
 try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:
     # package is not installed
-    pass
+    __version__ = '0.0.0'

--- a/xtimeutil/__init__.py
+++ b/xtimeutil/__init__.py
@@ -2,8 +2,8 @@
 """ Top-level module for xtime. """
 from pkg_resources import DistributionNotFound, get_distribution
 
-from .axis import Axis  # noqa: F401
-from .remapper import Remapper  # noqa: F401
+# from .axis import Axis  # noqa: F401
+# from .remapper import Remapper  # noqa: F401
 
 try:
     __version__ = get_distribution(__name__).version

--- a/xtimeutil/axis.py
+++ b/xtimeutil/axis.py
@@ -71,7 +71,6 @@ def get_time_axis_info(ds, time_coord_name='time', binding=None):
         time_attrs['calendar'],
         info['use_cftime'],
     )
-
     info.update(time_attrs)
 
     np_datetime_like = xr.core.common.is_np_datetime_like(decoded_time_bounds)
@@ -129,59 +128,48 @@ def _get_decoded_time(
 ):
 
     if is_time_decoded:
-        print('I am here')
-
         decoded_times = ds[time_coord_name].copy()
         decoded_time_bounds = ds[time_bounds_varname].copy()
 
     else:
-
         times = xr.coding.times.decode_cf_datetime(
             BINDINGS[binding](encoded_time_bounds, axis=time_bounds_dim_axis_num),
             units,
             calendar,
             use_cftime=use_cftime,
         )
-
         decoded_times = xr.DataArray(
             times,
             dims=[time_coord_name],
             coords={time_coord_name: times},
             attrs=ds[time_coord_name].attrs,
         )
-
         time_bounds = xr.coding.times.decode_cf_datetime(
             encoded_time_bounds, units, calendar, use_cftime=use_cftime,
         )
         decoded_time_bounds = xr.DataArray(
             time_bounds, dims=time_bounds_dims, attrs=ds[time_bounds_varname].attrs,
         )
-
     return decoded_times, decoded_time_bounds
 
 
 def _get_time_attrs(ds, time_coord_name):
     attrs = getattr(ds[time_coord_name], 'attrs')
     encoding = getattr(ds[time_coord_name], 'encoding')
-
     if 'units' in attrs:
         units = attrs['units']
     elif 'units' in encoding:
         units = encoding['units']
-
     if 'calendar' in attrs:
         calendar = attrs['calendar']
     elif 'calendar' in encoding:
         calendar = encoding['calendar']
     else:
         calendar = 'standard'
-
     if 'bounds' in attrs:
         time_bounds_varname = attrs['bounds']
-
     elif 'bounds' in encoding:
         time_bounds_varname = encoding['bounds']
-
     else:
         message = f'Unable to infer the {time_coord_name} coordinate boundary variable'
         # TODO: Tell the user how to generate/provide time bounds.
@@ -201,7 +189,6 @@ def _get_time_attrs(ds, time_coord_name):
 
 
 def _get_time_bounds_dims(time_bounds_dim_axis_num, time_bounds_dim, time_coord_name):
-
     if time_bounds_dim_axis_num == 1:
         dims = [time_coord_name, time_bounds_dim]
     else:
@@ -222,12 +209,9 @@ def _is_time_decoded(x):
 def _use_cftime(x, units, calendar):
     if xr.core.common.contains_cftime_datetimes(x):
         return True
-
     elif xr.core.common.is_np_datetime_like(x.dtype):
         return False
-
     else:
-
         dummy = xr.coding.times.decode_cf_datetime(x[:2], units=units, calendar=calendar)
         if xr.core.common.is_np_datetime_like(np.array(dummy).dtype):
             return False
@@ -236,19 +220,15 @@ def _use_cftime(x, units, calendar):
 
 
 def _infer_time_data_tick_binding(sample_time_bound, sample_time_data_tick):
-
     if np.isclose(sample_time_data_tick, sample_time_bound[1]):
         return 'right'
-
     elif np.isclose(sample_time_data_tick, sample_time_bound[0]):
         return 'left'
-
     elif np.isclose(
         sample_time_data_tick,
         sample_time_bound[0] + (sample_time_bound[1] - sample_time_bound[0]) / 2.0,
     ):
         return 'middle'
-
     else:
         message = f"""Unable to infer time data tick binding from the input data set.
                    Please specify the `binding` parameter. Accepted values: {list(BINDINGS.keys())}"""

--- a/xtimeutil/remapper.py
+++ b/xtimeutil/remapper.py
@@ -1,14 +1,15 @@
 import re
-import warnings
-from collections import OrderedDict
 
-import numpy as np
-import pandas as pd
-import sparse
-import xarray as xr
-from scipy.sparse import csr_matrix
+# import warnings
+# from collections import OrderedDict
 
-from .axis import Axis, _get_time_bounds_dims
+# import numpy as np
+# import pandas as pd
+# import sparse
+# import xarray as xr
+# from scipy.sparse import csr_matrix
+
+# from .axis import _get_time_bounds_dims
 
 _FREQUENCIES = {
     'A': 'AS',
@@ -97,245 +98,245 @@ def _validate_freq(freq):
     return f'{multiples}{_FREQUENCIES[freq]}'
 
 
-class Remapper:
-    """ An object that facilitates conversion between two time axis.
-    """
+# class Remapper:
+#     """ An object that facilitates conversion between two time axis.
+#     """
 
-    def __init__(self, ds, freq, time_coord_name='time', binding=None):
-        """
-        Create a new Remapper object that facilitates conversion between two time axis.
+#     def __init__(self, ds, freq, time_coord_name='time', binding=None):
+#         """
+#         Create a new Remapper object that facilitates conversion between two time axis.
 
-        Parameters
-        ----------
-        ds : xarray.Dataset
-            Contains the relevant time coordinate information.
-        freq : str / frequency object
-            The offset object representing target conversion also known as resampling
-            frequency (e.g., 'MS', '2D', 'H', or '3T' For full specification of available
-            frequencies, please see `here
-            <https://xarray.pydata.org/en/stable/generated/xarray.cftime_range.html>`_.
-        time_coord_name : str, optional
-            Name of the time coordinate, by default 'time'
-        binding : {'left', 'right', 'middle'}, optional
-            Defines different ways time data tick could be bound to an interval.
-            If None (default), attempt at inferring the time data tick binding from the
-            input data set.
+#         Parameters
+#         ----------
+#         ds : xarray.Dataset
+#             Contains the relevant time coordinate information.
+#         freq : str / frequency object
+#             The offset object representing target conversion also known as resampling
+#             frequency (e.g., 'MS', '2D', 'H', or '3T' For full specification of available
+#             frequencies, please see `here
+#             <https://xarray.pydata.org/en/stable/generated/xarray.cftime_range.html>`_.
+#         time_coord_name : str, optional
+#             Name of the time coordinate, by default 'time'
+#         binding : {'left', 'right', 'middle'}, optional
+#             Defines different ways time data tick could be bound to an interval.
+#             If None (default), attempt at inferring the time data tick binding from the
+#             input data set.
 
-            - `left`: means that the data tick is bound to the left/beginning of
-              the interval or the lower time bound.
+#             - `left`: means that the data tick is bound to the left/beginning of
+#               the interval or the lower time bound.
 
-            - `right`: means that the data tick is bound to the right/end of the
-               interval or the upper time bound.
+#             - `right`: means that the data tick is bound to the right/end of the
+#                interval or the upper time bound.
 
-            - `middle`: means that the data tick is bound half-way through between
-               lower time bound and upper time bound.
+#             - `middle`: means that the data tick is bound half-way through between
+#                lower time bound and upper time bound.
 
-        """
-        self._ds = ds
-        self._from_axis = Axis(ds, time_coord_name, binding)
-        self.info = self._construct_remapper_info(freq)
+#         """
+#         self._ds = ds
+#         self._from_axis = Axis(ds, time_coord_name, binding)
+#         self.info = self._construct_remapper_info(freq)
 
-    def _construct_remapper_info(self, freq):
-        freq = _validate_freq(freq)
-        binding = self._from_axis.attrs['binding']
-        ti = self._from_axis.decoded_time_bounds.values.flatten().min()
-        tf = self._from_axis.decoded_time_bounds.values.flatten().max()
+#     def _construct_remapper_info(self, freq):
+#         freq = _validate_freq(freq)
+#         binding = self._from_axis.attrs['binding']
+#         ti = self._from_axis.decoded_time_bounds.values.flatten().min()
+#         tf = self._from_axis.decoded_time_bounds.values.flatten().max()
 
-        incoming_time_bounds = self._from_axis.decoded_time_bounds
-        outgoing_time_bounds = _generate_outgoing_time_bounds(
-            incoming_time_bounds, freq, ti, tf, self._from_axis.attrs
-        )
+#         incoming_time_bounds = self._from_axis.decoded_time_bounds
+#         outgoing_time_bounds = _generate_outgoing_time_bounds(
+#             incoming_time_bounds, freq, ti, tf, self._from_axis.attrs
+#         )
 
-        wgts, col_idx, row_idx = self._get_coverage_matrix(
-            incoming_time_bounds, outgoing_time_bounds
-        )
+#         wgts, col_idx, row_idx = self._get_coverage_matrix(
+#             incoming_time_bounds, outgoing_time_bounds
+#         )
 
-        c = xr.Dataset()
-        c['weights'] = xr.DataArray(
-            sparse.COO.from_scipy_sparse(wgts), dims=['outgoing', 'incoming']
-        )
-        c['row_idx'] = row_idx
-        c['col_idx'] = col_idx
-        c['ti'] = ti
-        c['tf'] = tf
-        c['outgoing_time_bounds'] = outgoing_time_bounds
-        c.attrs['freq'] = freq
-        c.attrs['binding'] = binding
-        c.attrs.update(self._from_axis.attrs)
+#         c = xr.Dataset()
+#         c['weights'] = xr.DataArray(
+#             sparse.COO.from_scipy_sparse(wgts), dims=['outgoing', 'incoming']
+#         )
+#         c['row_idx'] = row_idx
+#         c['col_idx'] = col_idx
+#         c['ti'] = ti
+#         c['tf'] = tf
+#         c['outgoing_time_bounds'] = outgoing_time_bounds
+#         c.attrs['freq'] = freq
+#         c.attrs['binding'] = binding
+#         c.attrs.update(self._from_axis.attrs)
 
-        return c
+#         return c
 
-    def _get_coverage_matrix(self, incoming_time_bounds, outgoing_time_bounds):
-        encoded_time_bounds_in, _, _ = xr.coding.times.encode_cf_datetime(incoming_time_bounds)
-        encoded_time_bounds_out, _, _ = xr.coding.times.encode_cf_datetime(outgoing_time_bounds)
+#     def _get_coverage_matrix(self, incoming_time_bounds, outgoing_time_bounds):
+#         encoded_time_bounds_in, _, _ = xr.coding.times.encode_cf_datetime(incoming_time_bounds)
+#         encoded_time_bounds_out, _, _ = xr.coding.times.encode_cf_datetime(outgoing_time_bounds)
 
-        if self._from_axis.attrs['time_bounds_dim_axis_num'] == 1:
-            from_lower_bound = encoded_time_bounds_in[:, 0]
-            from_upper_bound = encoded_time_bounds_in[:, 1]
-            to_lower_bound = encoded_time_bounds_out[:, 0]
-            to_upper_bound = encoded_time_bounds_out[:, 1]
+#         if self._from_axis.attrs['time_bounds_dim_axis_num'] == 1:
+#             from_lower_bound = encoded_time_bounds_in[:, 0]
+#             from_upper_bound = encoded_time_bounds_in[:, 1]
+#             to_lower_bound = encoded_time_bounds_out[:, 0]
+#             to_upper_bound = encoded_time_bounds_out[:, 1]
 
-        else:
-            from_lower_bound = encoded_time_bounds_in[0, :]
-            from_upper_bound = encoded_time_bounds_in[1, :]
-            to_lower_bound = encoded_time_bounds_out[0, :]
-            to_upper_bound = encoded_time_bounds_out[1, :]
+#         else:
+#             from_lower_bound = encoded_time_bounds_in[0, :]
+#             from_upper_bound = encoded_time_bounds_in[1, :]
+#             to_lower_bound = encoded_time_bounds_out[0, :]
+#             to_upper_bound = encoded_time_bounds_out[1, :]
 
-        m = to_lower_bound.size
-        n = from_lower_bound.size
+#         m = to_lower_bound.size
+#         n = from_lower_bound.size
 
-        row_idx = []
-        col_idx = []
-        weights = []
-        for r in range(m):
-            toLB = to_lower_bound[r]
-            toUB = to_upper_bound[r]
-            toLength = toUB - toLB
-            for c in range(n):
-                fromLB = from_lower_bound[c]
-                fromUB = from_upper_bound[c]
-                fromLength = fromUB - fromLB
+#         row_idx = []
+#         col_idx = []
+#         weights = []
+#         for r in range(m):
+#             toLB = to_lower_bound[r]
+#             toUB = to_upper_bound[r]
+#             toLength = toUB - toLB
+#             for c in range(n):
+#                 fromLB = from_lower_bound[c]
+#                 fromUB = from_upper_bound[c]
+#                 fromLength = fromUB - fromLB
 
-                if (fromUB <= toLB) or (fromLB >= toUB):  # No coverage
-                    continue
-                elif (fromLB <= toLB) and (fromUB >= toLB) and (fromUB <= toUB):
-                    row_idx.append(r)
-                    col_idx.append(c)
-                    fraction_overlap = (fromUB - toLB) / fromLength
-                    weights.append(fraction_overlap * (fromLength / toLength))
-                elif (fromLB >= toLB) and (fromLB < toUB) and (fromUB >= toUB):
-                    row_idx.append(r)
-                    col_idx.append(c)
-                    fraction_overlap = (toUB - fromLB) / fromLength
-                    weights.append(fraction_overlap * (fromLength / toLength))
-                elif (fromLB >= toLB) and (fromUB <= toUB):
-                    row_idx.append(r)
-                    col_idx.append(c)
-                    fraction_overlap = 1.0
-                    weights.append(fraction_overlap * (fromLength / toLength))
-                elif (fromLB <= toLB) and (fromUB >= toUB):
-                    row_idx.append(r)
-                    col_idx.append(c)
-                    fraction_overlap = (toUB - toLB) / fromLength
-                    weights.append(fraction_overlap * (fromLength / toLength))
+#                 if (fromUB <= toLB) or (fromLB >= toUB):  # No coverage
+#                     continue
+#                 elif (fromLB <= toLB) and (fromUB >= toLB) and (fromUB <= toUB):
+#                     row_idx.append(r)
+#                     col_idx.append(c)
+#                     fraction_overlap = (fromUB - toLB) / fromLength
+#                     weights.append(fraction_overlap * (fromLength / toLength))
+#                 elif (fromLB >= toLB) and (fromLB < toUB) and (fromUB >= toUB):
+#                     row_idx.append(r)
+#                     col_idx.append(c)
+#                     fraction_overlap = (toUB - fromLB) / fromLength
+#                     weights.append(fraction_overlap * (fromLength / toLength))
+#                 elif (fromLB >= toLB) and (fromUB <= toUB):
+#                     row_idx.append(r)
+#                     col_idx.append(c)
+#                     fraction_overlap = 1.0
+#                     weights.append(fraction_overlap * (fromLength / toLength))
+#                 elif (fromLB <= toLB) and (fromUB >= toUB):
+#                     row_idx.append(r)
+#                     col_idx.append(c)
+#                     fraction_overlap = (toUB - toLB) / fromLength
+#                     weights.append(fraction_overlap * (fromLength / toLength))
 
-        wgts = csr_matrix((weights, (row_idx, col_idx)), shape=(m, n)).tolil()
-        mask = np.asarray(wgts.sum(axis=1)).flatten() == 0
-        wgts[mask, 0] = np.nan
-        wgts = wgts.tocsr()
+#         wgts = csr_matrix((weights, (row_idx, col_idx)), shape=(m, n)).tolil()
+#         mask = np.asarray(wgts.sum(axis=1)).flatten() == 0
+#         wgts[mask, 0] = np.nan
+#         wgts = wgts.tocsr()
 
-        return wgts, col_idx, row_idx
+#         return wgts, col_idx, row_idx
 
-    def _prepare_input_data(self, da):
-        n = self.info.weights.data.shape[1]
-        data = da.data.copy()
-        time_axis = _get_time_axis_dim_num(self._from_axis.attrs, da)
-        if data.ndim == 1:
-            data = data.reshape((-1, 1))
+#     def _prepare_input_data(self, da):
+#         n = self.info.weights.data.shape[1]
+#         data = da.data.copy()
+#         time_axis = _get_time_axis_dim_num(self._from_axis.attrs, da)
+#         if data.ndim == 1:
+#             data = data.reshape((-1, 1))
 
-        if data.shape[time_axis] != n:
-            message = f"""The length ({data.shape[time_axis]}) of input time dimension does not
-            match to that of the provided remapper ({n})"""
-            raise ValueError(message)
+#         if data.shape[time_axis] != n:
+#             message = f"""The length ({data.shape[time_axis]}) of input time dimension does not
+#             match to that of the provided remapper ({n})"""
+#             raise ValueError(message)
 
-        if time_axis != 0:
-            data = np.moveaxis(data, time_axis, 0)
+#         if time_axis != 0:
+#             data = np.moveaxis(data, time_axis, 0)
 
-        trailing_shape = data.shape[1:]
-        data = data.reshape((n, -1))
+#         trailing_shape = data.shape[1:]
+#         data = data.reshape((n, -1))
 
-        return data, trailing_shape
+#         return data, trailing_shape
 
-    def _prepare_output_data(self, input_data, output_data, time_axis, trailing_shape):
+#     def _prepare_output_data(self, input_data, output_data, time_axis, trailing_shape):
 
-        shape = (output_data.shape[0], *trailing_shape)
-        data = np.moveaxis(output_data.reshape(shape), 0, time_axis)
+#         shape = (output_data.shape[0], *trailing_shape)
+#         data = np.moveaxis(output_data.reshape(shape), 0, time_axis)
 
-        original_dims = input_data.dims
-        coords = OrderedDict()
-        dims = []
-        for dim in original_dims:
-            if dim != self._from_axis.attrs['time_coord_name']:
-                if dim in input_data.coords:
-                    coords[dim] = input_data.coords[dim]
-                    dims.append(dim)
-            else:
+#         original_dims = input_data.dims
+#         coords = OrderedDict()
+#         dims = []
+#         for dim in original_dims:
+#             if dim != self._from_axis.attrs['time_coord_name']:
+#                 if dim in input_data.coords:
+#                     coords[dim] = input_data.coords[dim]
+#                     dims.append(dim)
+#             else:
 
-                times = self._from_axis._bindings[self.info.attrs['binding']](
-                    self.info.outgoing_time_bounds,
-                    axis=self.info.attrs['time_bounds_dim_axis_num'],
-                )
-                times = xr.DataArray(times)
-                coords[dim] = xr.DataArray(
-                    times,
-                    coords={self.info.attrs['time_coord_name']: times},
-                    attrs=input_data.attrs,
-                )
-                dims.append(dim)
+#                 times = self._from_axis._bindings[self.info.attrs['binding']](
+#                     self.info.outgoing_time_bounds,
+#                     axis=self.info.attrs['time_bounds_dim_axis_num'],
+#                 )
+#                 times = xr.DataArray(times)
+#                 coords[dim] = xr.DataArray(
+#                     times,
+#                     coords={self.info.attrs['time_coord_name']: times},
+#                     attrs=input_data.attrs,
+#                 )
+#                 dims.append(dim)
 
-        return xr.DataArray(data, dims=dims, coords=coords)
+#         return xr.DataArray(data, dims=dims, coords=coords)
 
-    def average(self, da):
-        time_axis = _get_time_axis_dim_num(self._from_axis.attrs, da)
-        input_data, trailing_shape = self._prepare_input_data(da)
-        nan_mask = np.isnan(input_data)
-        non_nan_mask = np.ones(input_data.shape, dtype=np.int8)
-        non_nan_mask[nan_mask] = 0
-        input_data[nan_mask] = 0
-        output_data = np.dot(self.info.weights.data, input_data)
-        output_data = self._prepare_output_data(da, output_data, time_axis, trailing_shape)
-        return output_data
-
-
-def _generate_outgoing_time_bounds(incoming_time_bounds, freq, ti, tf, attrs):
-
-    warning_message = f'Resample frequency is greater than extent of incoming time axis. Doubling time axis interval.'
-
-    if xr.core.common.is_np_datetime_like(incoming_time_bounds.dtype):
-        # Use to_offset() function to compute offset that allows us to generate
-        # time range that includes the end of the incoming time bounds.
-        offset = pd.tseries.frequencies.to_offset(freq)
-
-        time_bounds = pd.date_range(start=pd.to_datetime(ti), end=pd.to_datetime(tf), freq=freq)
-
-        if (len(time_bounds) == 1) or (time_bounds[-1] < tf):
-            # this should be rare
-            if len(time_bounds) == 1:
-                warnings.warn(warning_message)
-
-            time_bounds = pd.date_range(
-                start=pd.to_datetime(ti), end=pd.to_datetime(tf) + offset, freq=freq,
-            )
-
-    else:
-        offset = xr.coding.cftime_offsets.to_offset(freq)
-        time_bounds = xr.cftime_range(start=ti, end=tf, freq=freq, calendar=attrs['calendar'],)
-
-        if (len(time_bounds) == 1) or (time_bounds[-1] < tf):
-            # this should be rare
-            if len(time_bounds) == 1:
-                warnings.warn(warning_message)
-
-            time_bounds = xr.cftime_range(
-                start=ti, end=tf + offset, freq=freq, calendar=attrs['calendar'],
-            )
-
-    msg = f"""{tf} upper bound from the incoming time axis is not covered in the outgoing
-    time axis which has {time_bounds[-1]} as the upper bound."""
-
-    assert time_bounds[-1] >= tf, msg
-    outgoing_time_bounds = np.vstack((time_bounds[:-1], time_bounds[1:])).T
-    dims = _get_time_bounds_dims(attrs)
-
-    if attrs['time_bounds_dim_axis_num'] == 0:
-        outgoing_time_bounds = outgoing_time_bounds.T
-
-    return xr.DataArray(dims=dims, data=outgoing_time_bounds)
+#     def average(self, da):
+#         time_axis = _get_time_axis_dim_num(self._from_axis.attrs, da)
+#         input_data, trailing_shape = self._prepare_input_data(da)
+#         nan_mask = np.isnan(input_data)
+#         non_nan_mask = np.ones(input_data.shape, dtype=np.int8)
+#         non_nan_mask[nan_mask] = 0
+#         input_data[nan_mask] = 0
+#         output_data = np.dot(self.info.weights.data, input_data)
+#         output_data = self._prepare_output_data(da, output_data, time_axis, trailing_shape)
+#         return output_data
 
 
-def _get_time_axis_dim_num(attrs, da):
-    """
-    Return the dimension number of the time axis coordinate in a DataArray.
-    """
-    time_coord_name = attrs['time_coord_name']
-    return da.get_axis_num(time_coord_name)
+# def _generate_outgoing_time_bounds(incoming_time_bounds, freq, ti, tf, attrs):
+
+#     warning_message = f'Resample frequency is greater than extent of incoming time axis. Doubling time axis interval.'
+
+#     if xr.core.common.is_np_datetime_like(incoming_time_bounds.dtype):
+#         # Use to_offset() function to compute offset that allows us to generate
+#         # time range that includes the end of the incoming time bounds.
+#         offset = pd.tseries.frequencies.to_offset(freq)
+
+#         time_bounds = pd.date_range(start=pd.to_datetime(ti), end=pd.to_datetime(tf), freq=freq)
+
+#         if (len(time_bounds) == 1) or (time_bounds[-1] < tf):
+#             # this should be rare
+#             if len(time_bounds) == 1:
+#                 warnings.warn(warning_message)
+
+#             time_bounds = pd.date_range(
+#                 start=pd.to_datetime(ti), end=pd.to_datetime(tf) + offset, freq=freq,
+#             )
+
+#     else:
+#         offset = xr.coding.cftime_offsets.to_offset(freq)
+#         time_bounds = xr.cftime_range(start=ti, end=tf, freq=freq, calendar=attrs['calendar'],)
+
+#         if (len(time_bounds) == 1) or (time_bounds[-1] < tf):
+#             # this should be rare
+#             if len(time_bounds) == 1:
+#                 warnings.warn(warning_message)
+
+#             time_bounds = xr.cftime_range(
+#                 start=ti, end=tf + offset, freq=freq, calendar=attrs['calendar'],
+#             )
+
+#     msg = f"""{tf} upper bound from the incoming time axis is not covered in the outgoing
+#     time axis which has {time_bounds[-1]} as the upper bound."""
+
+#     assert time_bounds[-1] >= tf, msg
+#     outgoing_time_bounds = np.vstack((time_bounds[:-1], time_bounds[1:])).T
+#     dims = _get_time_bounds_dims(attrs)
+
+#     if attrs['time_bounds_dim_axis_num'] == 0:
+#         outgoing_time_bounds = outgoing_time_bounds.T
+
+#     return xr.DataArray(dims=dims, data=outgoing_time_bounds)
+
+
+# def _get_time_axis_dim_num(attrs, da):
+#     """
+#     Return the dimension number of the time axis coordinate in a DataArray.
+#     """
+#     time_coord_name = attrs['time_coord_name']
+#     return da.get_axis_num(time_coord_name)

--- a/xtimeutil/remapper.py
+++ b/xtimeutil/remapper.py
@@ -1,15 +1,13 @@
 import re
+import warnings
 
-# import warnings
-# from collections import OrderedDict
+import numpy as np
+import pandas as pd
+import sparse
+import xarray as xr
+from scipy.sparse import csr_matrix
 
-# import numpy as np
-# import pandas as pd
-# import sparse
-# import xarray as xr
-# from scipy.sparse import csr_matrix
-
-# from .axis import _get_time_bounds_dims
+from .axis import BINDINGS, get_time_axis_info
 
 _FREQUENCIES = {
     'A': 'AS',
@@ -98,245 +96,221 @@ def _validate_freq(freq):
     return f'{multiples}{_FREQUENCIES[freq]}'
 
 
-# class Remapper:
-#     """ An object that facilitates conversion between two time axis.
-#     """
+class Remapper:
+    """ An object that facilitates conversion between two time axis.
+    """
 
-#     def __init__(self, ds, freq, time_coord_name='time', binding=None):
-#         """
-#         Create a new Remapper object that facilitates conversion between two time axis.
+    def __init__(self, ds, freq, time_coord_name='time', binding=None):
+        """
+        Create a new Remapper object that facilitates conversion between two time axis.
 
-#         Parameters
-#         ----------
-#         ds : xarray.Dataset
-#             Contains the relevant time coordinate information.
-#         freq : str / frequency object
-#             The offset object representing target conversion also known as resampling
-#             frequency (e.g., 'MS', '2D', 'H', or '3T' For full specification of available
-#             frequencies, please see `here
-#             <https://xarray.pydata.org/en/stable/generated/xarray.cftime_range.html>`_.
-#         time_coord_name : str, optional
-#             Name of the time coordinate, by default 'time'
-#         binding : {'left', 'right', 'middle'}, optional
-#             Defines different ways time data tick could be bound to an interval.
-#             If None (default), attempt at inferring the time data tick binding from the
-#             input data set.
+        Parameters
+        ----------
+        ds : xarray.Dataset
+            Contains the relevant time coordinate information.
+        freq : str / frequency object
+            The offset object representing target conversion also known as resampling
+            frequency (e.g., 'MS', '2D', 'H', or '3T' For full specification of available
+            frequencies, please see `here
+            <https://xarray.pydata.org/en/stable/generated/xarray.cftime_range.html>`_.
+        time_coord_name : str, optional
+            Name of the time coordinate, by default 'time'
+        binding : {'left', 'right', 'middle'}, optional
+            Defines different ways time data tick could be bound to an interval.
+            If None (default), attempt at inferring the time data tick binding from the
+            input data set.
 
-#             - `left`: means that the data tick is bound to the left/beginning of
-#               the interval or the lower time bound.
+            - `left`: means that the data tick is bound to the left/beginning of
+              the interval or the lower time bound.
 
-#             - `right`: means that the data tick is bound to the right/end of the
-#                interval or the upper time bound.
+            - `right`: means that the data tick is bound to the right/end of the
+               interval or the upper time bound.
 
-#             - `middle`: means that the data tick is bound half-way through between
-#                lower time bound and upper time bound.
+            - `middle`: means that the data tick is bound half-way through between
+               lower time bound and upper time bound.
 
-#         """
-#         self._ds = ds
-#         self._from_axis = Axis(ds, time_coord_name, binding)
-#         self.info = self._construct_remapper_info(freq)
+        """
+        self._ds = ds
+        freq = _validate_freq(freq)
+        self.incoming = get_time_axis_info(ds, time_coord_name, binding)
+        ti = self.incoming['decoded_time_bounds'].values.flatten().min()
+        tf = self.incoming['decoded_time_bounds'].values.flatten().max()
+        self.info = {'ti': ti, 'tf': tf, 'freq': freq, 'binding': self.incoming['binding']}
+        self.outgoing = self.get_outgoing_time_axis_info()
+        self.coverage = _get_coverage_info(
+            self.incoming['encoded_time_bounds'].values,
+            self.outgoing['encoded_time_bounds'].values,
+            self.incoming['time_bounds_dim_axis_num'],
+        )
+        self.weights = construct_coverage_matrix(
+            self.coverage['weights'],
+            self.coverage['col_idx'],
+            self.coverage['row_idx'],
+            self.coverage['shape'],
+        )
 
-#     def _construct_remapper_info(self, freq):
-#         freq = _validate_freq(freq)
-#         binding = self._from_axis.attrs['binding']
-#         ti = self._from_axis.decoded_time_bounds.values.flatten().min()
-#         tf = self._from_axis.decoded_time_bounds.values.flatten().max()
+    def get_outgoing_time_axis_info(self):
+        attrs = {'units': self.incoming['units'], 'calendar': self.incoming['calendar']}
+        attrs.update(self._ds[self.incoming['time_coord_name']].attrs)
+        outgoing_decoded_time_bounds = _construct_outgoing_time_bounds(
+            self.info['freq'],
+            self.info['ti'],
+            self.info['tf'],
+            attrs['calendar'],
+            self.incoming['np_datetime_like'],
+            self.incoming['time_bounds_dim_axis_num'],
+            self.incoming['time_bounds_dims'],
+        )
+        time_bounds, _, _ = xr.coding.times.encode_cf_datetime(
+            outgoing_decoded_time_bounds, units=attrs['units'], calendar=attrs['calendar']
+        )
+        times = BINDINGS[self.info['binding']](
+            time_bounds, axis=self.incoming['time_bounds_dim_axis_num']
+        )
 
-#         incoming_time_bounds = self._from_axis.decoded_time_bounds
-#         outgoing_time_bounds = _generate_outgoing_time_bounds(
-#             incoming_time_bounds, freq, ti, tf, self._from_axis.attrs
-#         )
+        outgoing_encoded_times = xr.DataArray(
+            times,
+            attrs=attrs,
+            dims=[self.incoming['time_coord_name']],
+            coords={self.incoming['time_coord_name']: times},
+        )
+        outgoing_encoded_time_bounds = xr.DataArray(
+            time_bounds,
+            dims=outgoing_decoded_time_bounds.dims,
+            coords={self.incoming['time_coord_name']: times},
+        )
 
-#         wgts, col_idx, row_idx = self._get_coverage_matrix(
-#             incoming_time_bounds, outgoing_time_bounds
-#         )
-
-#         c = xr.Dataset()
-#         c['weights'] = xr.DataArray(
-#             sparse.COO.from_scipy_sparse(wgts), dims=['outgoing', 'incoming']
-#         )
-#         c['row_idx'] = row_idx
-#         c['col_idx'] = col_idx
-#         c['ti'] = ti
-#         c['tf'] = tf
-#         c['outgoing_time_bounds'] = outgoing_time_bounds
-#         c.attrs['freq'] = freq
-#         c.attrs['binding'] = binding
-#         c.attrs.update(self._from_axis.attrs)
-
-#         return c
-
-#     def _get_coverage_matrix(self, incoming_time_bounds, outgoing_time_bounds):
-#         encoded_time_bounds_in, _, _ = xr.coding.times.encode_cf_datetime(incoming_time_bounds)
-#         encoded_time_bounds_out, _, _ = xr.coding.times.encode_cf_datetime(outgoing_time_bounds)
-
-#         if self._from_axis.attrs['time_bounds_dim_axis_num'] == 1:
-#             from_lower_bound = encoded_time_bounds_in[:, 0]
-#             from_upper_bound = encoded_time_bounds_in[:, 1]
-#             to_lower_bound = encoded_time_bounds_out[:, 0]
-#             to_upper_bound = encoded_time_bounds_out[:, 1]
-
-#         else:
-#             from_lower_bound = encoded_time_bounds_in[0, :]
-#             from_upper_bound = encoded_time_bounds_in[1, :]
-#             to_lower_bound = encoded_time_bounds_out[0, :]
-#             to_upper_bound = encoded_time_bounds_out[1, :]
-
-#         m = to_lower_bound.size
-#         n = from_lower_bound.size
-
-#         row_idx = []
-#         col_idx = []
-#         weights = []
-#         for r in range(m):
-#             toLB = to_lower_bound[r]
-#             toUB = to_upper_bound[r]
-#             toLength = toUB - toLB
-#             for c in range(n):
-#                 fromLB = from_lower_bound[c]
-#                 fromUB = from_upper_bound[c]
-#                 fromLength = fromUB - fromLB
-
-#                 if (fromUB <= toLB) or (fromLB >= toUB):  # No coverage
-#                     continue
-#                 elif (fromLB <= toLB) and (fromUB >= toLB) and (fromUB <= toUB):
-#                     row_idx.append(r)
-#                     col_idx.append(c)
-#                     fraction_overlap = (fromUB - toLB) / fromLength
-#                     weights.append(fraction_overlap * (fromLength / toLength))
-#                 elif (fromLB >= toLB) and (fromLB < toUB) and (fromUB >= toUB):
-#                     row_idx.append(r)
-#                     col_idx.append(c)
-#                     fraction_overlap = (toUB - fromLB) / fromLength
-#                     weights.append(fraction_overlap * (fromLength / toLength))
-#                 elif (fromLB >= toLB) and (fromUB <= toUB):
-#                     row_idx.append(r)
-#                     col_idx.append(c)
-#                     fraction_overlap = 1.0
-#                     weights.append(fraction_overlap * (fromLength / toLength))
-#                 elif (fromLB <= toLB) and (fromUB >= toUB):
-#                     row_idx.append(r)
-#                     col_idx.append(c)
-#                     fraction_overlap = (toUB - toLB) / fromLength
-#                     weights.append(fraction_overlap * (fromLength / toLength))
-
-#         wgts = csr_matrix((weights, (row_idx, col_idx)), shape=(m, n)).tolil()
-#         mask = np.asarray(wgts.sum(axis=1)).flatten() == 0
-#         wgts[mask, 0] = np.nan
-#         wgts = wgts.tocsr()
-
-#         return wgts, col_idx, row_idx
-
-#     def _prepare_input_data(self, da):
-#         n = self.info.weights.data.shape[1]
-#         data = da.data.copy()
-#         time_axis = _get_time_axis_dim_num(self._from_axis.attrs, da)
-#         if data.ndim == 1:
-#             data = data.reshape((-1, 1))
-
-#         if data.shape[time_axis] != n:
-#             message = f"""The length ({data.shape[time_axis]}) of input time dimension does not
-#             match to that of the provided remapper ({n})"""
-#             raise ValueError(message)
-
-#         if time_axis != 0:
-#             data = np.moveaxis(data, time_axis, 0)
-
-#         trailing_shape = data.shape[1:]
-#         data = data.reshape((n, -1))
-
-#         return data, trailing_shape
-
-#     def _prepare_output_data(self, input_data, output_data, time_axis, trailing_shape):
-
-#         shape = (output_data.shape[0], *trailing_shape)
-#         data = np.moveaxis(output_data.reshape(shape), 0, time_axis)
-
-#         original_dims = input_data.dims
-#         coords = OrderedDict()
-#         dims = []
-#         for dim in original_dims:
-#             if dim != self._from_axis.attrs['time_coord_name']:
-#                 if dim in input_data.coords:
-#                     coords[dim] = input_data.coords[dim]
-#                     dims.append(dim)
-#             else:
-
-#                 times = self._from_axis._bindings[self.info.attrs['binding']](
-#                     self.info.outgoing_time_bounds,
-#                     axis=self.info.attrs['time_bounds_dim_axis_num'],
-#                 )
-#                 times = xr.DataArray(times)
-#                 coords[dim] = xr.DataArray(
-#                     times,
-#                     coords={self.info.attrs['time_coord_name']: times},
-#                     attrs=input_data.attrs,
-#                 )
-#                 dims.append(dim)
-
-#         return xr.DataArray(data, dims=dims, coords=coords)
-
-#     def average(self, da):
-#         time_axis = _get_time_axis_dim_num(self._from_axis.attrs, da)
-#         input_data, trailing_shape = self._prepare_input_data(da)
-#         nan_mask = np.isnan(input_data)
-#         non_nan_mask = np.ones(input_data.shape, dtype=np.int8)
-#         non_nan_mask[nan_mask] = 0
-#         input_data[nan_mask] = 0
-#         output_data = np.dot(self.info.weights.data, input_data)
-#         output_data = self._prepare_output_data(da, output_data, time_axis, trailing_shape)
-#         return output_data
+        decoded_times = xr.coding.times.decode_cf_datetime(
+            times,
+            units=attrs['units'],
+            calendar=attrs['calendar'],
+            use_cftime=self.incoming['use_cftime'],
+        )
+        outgoing_decoded_times = xr.DataArray(
+            decoded_times,
+            attrs=attrs,
+            dims=[self.incoming['time_coord_name']],
+            coords={self.incoming['time_coord_name']: decoded_times},
+        )
+        x = {
+            'decoded_time_bounds': outgoing_decoded_time_bounds,
+            'encoded_time_bounds': outgoing_encoded_time_bounds,
+            'encoded_times': outgoing_encoded_times,
+            'decoded_times': outgoing_decoded_times,
+        }
+        x.update(attrs)
+        return x
 
 
-# def _generate_outgoing_time_bounds(incoming_time_bounds, freq, ti, tf, attrs):
-
-#     warning_message = f'Resample frequency is greater than extent of incoming time axis. Doubling time axis interval.'
-
-#     if xr.core.common.is_np_datetime_like(incoming_time_bounds.dtype):
-#         # Use to_offset() function to compute offset that allows us to generate
-#         # time range that includes the end of the incoming time bounds.
-#         offset = pd.tseries.frequencies.to_offset(freq)
-
-#         time_bounds = pd.date_range(start=pd.to_datetime(ti), end=pd.to_datetime(tf), freq=freq)
-
-#         if (len(time_bounds) == 1) or (time_bounds[-1] < tf):
-#             # this should be rare
-#             if len(time_bounds) == 1:
-#                 warnings.warn(warning_message)
-
-#             time_bounds = pd.date_range(
-#                 start=pd.to_datetime(ti), end=pd.to_datetime(tf) + offset, freq=freq,
-#             )
-
-#     else:
-#         offset = xr.coding.cftime_offsets.to_offset(freq)
-#         time_bounds = xr.cftime_range(start=ti, end=tf, freq=freq, calendar=attrs['calendar'],)
-
-#         if (len(time_bounds) == 1) or (time_bounds[-1] < tf):
-#             # this should be rare
-#             if len(time_bounds) == 1:
-#                 warnings.warn(warning_message)
-
-#             time_bounds = xr.cftime_range(
-#                 start=ti, end=tf + offset, freq=freq, calendar=attrs['calendar'],
-#             )
-
-#     msg = f"""{tf} upper bound from the incoming time axis is not covered in the outgoing
-#     time axis which has {time_bounds[-1]} as the upper bound."""
-
-#     assert time_bounds[-1] >= tf, msg
-#     outgoing_time_bounds = np.vstack((time_bounds[:-1], time_bounds[1:])).T
-#     dims = _get_time_bounds_dims(attrs)
-
-#     if attrs['time_bounds_dim_axis_num'] == 0:
-#         outgoing_time_bounds = outgoing_time_bounds.T
-
-#     return xr.DataArray(dims=dims, data=outgoing_time_bounds)
+def construct_coverage_matrix(weights, col_idx, row_idx, shape):
+    wgts = csr_matrix((weights, (row_idx, col_idx)), shape=shape).tolil()
+    mask = np.asarray(wgts.sum(axis=1)).flatten() == 0
+    wgts[mask, 0] = np.nan
+    wgts = wgts.tocsr()
+    weights = sparse.COO.from_scipy_sparse(wgts)
+    return weights
 
 
-# def _get_time_axis_dim_num(attrs, da):
-#     """
-#     Return the dimension number of the time axis coordinate in a DataArray.
-#     """
-#     time_coord_name = attrs['time_coord_name']
-#     return da.get_axis_num(time_coord_name)
+def _get_coverage_info(
+    incoming_encoded_time_bounds, outgoing_encoded_time_bounds, time_bounds_dim_axis_num
+):
+
+    if time_bounds_dim_axis_num == 1:
+        incoming_lower_bounds = incoming_encoded_time_bounds[:, 0]
+        incoming_upper_bounds = incoming_encoded_time_bounds[:, 1]
+        outgoing_lower_bounds = outgoing_encoded_time_bounds[:, 0]
+        outgoing_upper_bounds = outgoing_encoded_time_bounds[:, 1]
+
+    else:
+        incoming_lower_bounds = incoming_encoded_time_bounds[0, :]
+        incoming_upper_bounds = incoming_encoded_time_bounds[1, :]
+        outgoing_lower_bounds = outgoing_encoded_time_bounds[0, :]
+        outgoing_upper_bounds = outgoing_encoded_time_bounds[1, :]
+
+    n = incoming_lower_bounds.size
+    m = outgoing_lower_bounds.size
+
+    row_idx = []
+    col_idx = []
+    weights = []
+    for r in range(m):
+        toLB = outgoing_lower_bounds[r]
+        toUB = outgoing_upper_bounds[r]
+        toLength = toUB - toLB
+        for c in range(n):
+            fromLB = incoming_lower_bounds[c]
+            fromUB = incoming_upper_bounds[c]
+            fromLength = fromUB - fromLB
+
+            if (fromUB <= toLB) or (fromLB >= toUB):  # No coverage
+                continue
+            elif (fromLB <= toLB) and (fromUB >= toLB) and (fromUB <= toUB):
+                row_idx.append(r)
+                col_idx.append(c)
+                fraction_overlap = (fromUB - toLB) / fromLength
+                weights.append(fraction_overlap * (fromLength / toLength))
+            elif (fromLB >= toLB) and (fromLB < toUB) and (fromUB >= toUB):
+                row_idx.append(r)
+                col_idx.append(c)
+                fraction_overlap = (toUB - fromLB) / fromLength
+                weights.append(fraction_overlap * (fromLength / toLength))
+            elif (fromLB >= toLB) and (fromUB <= toUB):
+                row_idx.append(r)
+                col_idx.append(c)
+                fraction_overlap = 1.0
+                weights.append(fraction_overlap * (fromLength / toLength))
+            elif (fromLB <= toLB) and (fromUB >= toUB):
+                row_idx.append(r)
+                col_idx.append(c)
+                fraction_overlap = (toUB - toLB) / fromLength
+                weights.append(fraction_overlap * (fromLength / toLength))
+
+    coverage = {'weights': weights, 'col_idx': col_idx, 'row_idx': row_idx, 'shape': (m, n)}
+    return coverage
+
+
+def _construct_outgoing_time_bounds(
+    freq, ti, tf, calendar, np_datetime_like, time_bounds_dim_axis_num, time_bounds_dims, attrs={}
+):
+
+    warning_message = f'Resample frequency={freq} is greater than extent of incoming time axis. Doubling outgoing time axis interval.'
+
+    if np_datetime_like:
+        # Use to_offset() function to compute offset that allows us to generate
+        # time range that includes the end of the incoming time bounds.
+        offset = pd.tseries.frequencies.to_offset(freq)
+
+        time_bounds = pd.date_range(start=pd.to_datetime(ti), end=pd.to_datetime(tf), freq=freq)
+
+        if (len(time_bounds) == 1) or (time_bounds[-1] < tf):
+            # this should be rare
+            if len(time_bounds) == 1:
+                warnings.warn(warning_message)
+
+            time_bounds = pd.date_range(
+                start=pd.to_datetime(ti), end=pd.to_datetime(tf) + offset, freq=freq,
+            )
+
+    else:
+        offset = xr.coding.cftime_offsets.to_offset(freq)
+        time_bounds = xr.cftime_range(start=ti, end=tf, freq=freq, calendar=calendar,)
+
+        if (len(time_bounds) == 1) or (time_bounds[-1] < tf):
+            # this should be rare
+            if len(time_bounds) == 1:
+                warnings.warn(warning_message)
+
+            time_bounds = xr.cftime_range(start=ti, end=tf + offset, freq=freq, calendar=calendar,)
+
+    msg = f"""{tf} upper bound from the incoming time axis is not covered in the outgoing
+    time axis which has {time_bounds[-1]} as the upper bound."""
+
+    assert time_bounds[-1] >= tf, msg
+    outgoing_time_bounds = np.vstack((time_bounds[:-1], time_bounds[1:])).T
+
+    if time_bounds_dim_axis_num == 0:
+        outgoing_time_bounds = outgoing_time_bounds.T
+
+    out = xr.DataArray(dims=time_bounds_dims, data=outgoing_time_bounds)
+    out.attrs = attrs
+    return out

--- a/xtimeutil/remapper.py
+++ b/xtimeutil/remapper.py
@@ -167,7 +167,6 @@ class Remapper:
         times = BINDINGS[self.info['binding']](
             time_bounds, axis=self.incoming['time_bounds_dim_axis_num']
         )
-
         outgoing_encoded_times = xr.DataArray(
             times,
             attrs=attrs,
@@ -179,7 +178,6 @@ class Remapper:
             dims=outgoing_decoded_time_bounds.dims,
             coords={self.incoming['time_coord_name']: times},
         )
-
         decoded_times = xr.coding.times.decode_cf_datetime(
             times,
             units=attrs['units'],
@@ -220,7 +218,6 @@ def _get_coverage_info(
         incoming_upper_bounds = incoming_encoded_time_bounds[:, 1]
         outgoing_lower_bounds = outgoing_encoded_time_bounds[:, 0]
         outgoing_upper_bounds = outgoing_encoded_time_bounds[:, 1]
-
     else:
         incoming_lower_bounds = incoming_encoded_time_bounds[0, :]
         incoming_upper_bounds = incoming_encoded_time_bounds[1, :]
@@ -279,9 +276,7 @@ def _construct_outgoing_time_bounds(
         # Use to_offset() function to compute offset that allows us to generate
         # time range that includes the end of the incoming time bounds.
         offset = pd.tseries.frequencies.to_offset(freq)
-
         time_bounds = pd.date_range(start=pd.to_datetime(ti), end=pd.to_datetime(tf), freq=freq)
-
         if (len(time_bounds) == 1) or (time_bounds[-1] < tf):
             # this should be rare
             if len(time_bounds) == 1:
@@ -294,7 +289,6 @@ def _construct_outgoing_time_bounds(
     else:
         offset = xr.coding.cftime_offsets.to_offset(freq)
         time_bounds = xr.cftime_range(start=ti, end=tf, freq=freq, calendar=calendar,)
-
         if (len(time_bounds) == 1) or (time_bounds[-1] < tf):
             # this should be rare
             if len(time_bounds) == 1:


### PR DESCRIPTION
- The `Axis` class had two methods (including `__init__`). So, it made sense to replace the `Axis` class with functions instead.

- I also made changes in `Remapper` to address some consistency issues throughout the code base 


- I removed the implementation for `average()` method and other utilities that were used during the remapping. I am planning on re-introducing these methods/utilities in a separate PR after verifying weights generation step. 
